### PR TITLE
feat!: add Unbyted v2.0.0

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -1,50 +1,37 @@
 export {}
-type R<T> = {
-  [P in keyof T]-?: T[P]
-}
 declare type UnbytedOptions = {
-  /** Trim decimal numbers when needed. (default: false) */
+  /**Trim decimal numbers when needed (default: false)*/
   trim?: boolean
-  /** Include unit's symbols or not. (default: true) */
+  /**Include unit's symbols or not (default: true)*/
   symbols?: boolean
-  /** Display bytes (B) unit or not. (default: false) */
+  /**Display bytes (B) unit or not (default: false)*/
   includeBytes?: boolean
-  /** The number of decimal places. (default: 2) */
-  decimals?: number
-  /** The bytes value in one binary unit. (default: `1024`) */
-  bytesInBinary?: number
-  /** The bytes value in one decimal unit. (default: `1000`) */
-  bytesInDecimal?: number
-  /** Define custom decimal units symbols. (Requires 7 strings) */
-  binaryUnits?: [string, string, string, string, string, string, string]
-  /** Define custom binary units symbols. (Requires 7 strings) */
-  decimalUnits?: [string, string, string, string, string, string, string]
+  /**The number of decimal places (default: 2)*/
+  digits?: number
+  /**Change the locales used (default: en-US)*/
+  locales?: string
+  /**Change the unit symbol display format (default: short)*/
+  unitDisplay?: 'long' | 'short' | 'narrow'
+  /**Change the conversion precision (default: 9)*/
+  precision?: number
 }
-declare type FC = R<UnbytedOptions>
 declare type UnbytedReturns = {
-  /**
-   * Formats bytes into readable `binary` measurement units
+  /**Formats bytes into readable `binary` measurement units
    * @param bytes the bytes to be formatted
-   * @return an string containing the formatted bytes
-   */
+   * @return an string containing the formatted bytes*/
   toBinaryString(bytes: number): string
-  /**
-   * Formats bytes into readable `decimal` measurement units
+  /**Formats bytes into readable `decimal` measurement units
    * @param bytes the bytes to be formatted
-   * @return an string containing the formatted bytes
-   */
+   * @return an string containing the formatted bytes*/
   toDecimalString(bytes: number): string
 }
-declare function autoFormat(bytes: number, key: 'binaryUnits' | 'decimalUnits', config: FC): string
-/**
- * Creates new Unbyted instance
+/**Creates new Unbyted instance
  * @param options the options to control how the bytes will be formatted
  * @return methods to turn bytes into readable measurement units
  * @example
  * ```js
  * unbyted().toBinaryString(1000) // Returns: 0.98 KiB
  * unbyted().toDecimalString(1000) // Returns: 1.00 KB
- * ```
- */
+ * ``` */
 declare function unbyted(options?: UnbytedOptions): UnbytedReturns
 export = unbyted

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ See more about [Unbyted measurement units](docs/MEASUREMENT_UNITS.md).
 
 ## Getting started
 
+After you run `npm i unbyted`, try it out:
+
 ```js
 import unbyted from 'unbyted' // OR: const unbyted = require('unbyted')
 
@@ -29,18 +31,7 @@ toBinaryString(1000) // Returns: 0.98 KiB
 toDecimalString(1000) // Returns: 1 KB
 ```
 
-### Customisation options
-
-| option           | type     | description                                               |
-| ---------------- | -------- | --------------------------------------------------------- |
-| `trim`           | boolean  | Trim decimal numbers when needed. (default: false)        |
-| `symbols`        | boolean  | Include unit's symbols or not. (default: true)            |
-| `includeBytes`   | boolean  | Display bytes (B) unit or not. (default: false)           |
-| `decimals`       | number   | The number of decimal places. (default: 2)                |
-| `bytesInBinary`  | number   | The bytes value in one binary unit. (default: `1024`)     |
-| `bytesInDecimal` | number   | The bytes value in one decimal unit. (default: `1000`)    |
-| `binaryUnits`    | string[] | Define custom binary units symbols. (Requires 7 strings)  |
-| `decimalUnits`   | string[] | Define custom decimal units symbols. (Requires 7 strings) |
+See the [API documentation](docs/UNBYTED_API.md) to learn more about options and usage.
 
 ## Contributing
 
@@ -50,4 +41,4 @@ See the [contributing guide](CONTRIBUTING.md) for detailed instructions on how t
 
 - 🙋 Ask questions at [Github Q&A](https://github.com/santosned/unbyted/discussions/categories/q-a)
 - 📝 Request new features at [Github Issues](https://github.com/santosned/unbyted/issues)
-- ⭐ Leave a star on the repo
+- ⭐ Leave a star on the [repo](https://github.com/santosned/unbyted)

--- a/docs/MEASUREMENT_UNITS.md
+++ b/docs/MEASUREMENT_UNITS.md
@@ -1,33 +1,37 @@
-# Measurement Units
+# Digital Measurement Units
+
+**Unbyted** supports a total of `16` customizable units 😋 🎉
+
+In comparission the [Intl.NumberFormat()](https://v8.dev/features/intl-numberformat) supports only `11` digital units.
 
 ### Binary
 
 | Name     | Symbol | Value  |
 | -------- | ------ | ------ |
-| Kibibyte | `KiB`  | `2^10` |
-| Mebibyte | `MiB`  | `2^20` |
-| Gibibyte | `GiB`  | `2^30` |
-| Tebibyte | `TiB`  | `2^40` |
-| Pebibyte | `PiB`  | `2^50` |
-| Exbibyte | `EiB`  | `2^60` |
+| Kibibyte | `KiB`  | `2e10` |
+| Mebibyte | `MiB`  | `2e20` |
+| Gibibyte | `GiB`  | `2e30` |
+| Tebibyte | `TiB`  | `2e40` |
+| Pebibyte | `PiB`  | `2e50` |
+| Exbibyte | `EiB`  | `2e60` |
+| Zebibyte | `ZiB`  | `2e70` |
+| Yobibyte | `YiB`  | `2e80` |
 
 ### Decimal
 
-| Name     | Symbol | Value   |
-| -------- | ------ | ------- |
-| Kilobyte | `KB`   | `10^3`  |
-| Megabyte | `MB`   | `10^6`  |
-| Gigabyte | `GB`   | `10^9`  |
-| Terabyte | `TB`   | `10^12` |
-| Petabyte | `PB`   | `10^15` |
-| Exabyte  | `EB`   | `10^18` |
+| Name      | Symbol | Value   |
+| --------- | ------ | ------- |
+| Kilobyte  | `KB`   | `10e3`  |
+| Megabyte  | `MB`   | `10e6`  |
+| Gigabyte  | `GB`   | `10e9`  |
+| Terabyte  | `TB`   | `10e12` |
+| Petabyte  | `PB`   | `10e15` |
+| Exabyte   | `EB`   | `10e18` |
+| Zettabyte | `ZB`   | `10e21` |
+| Yottabyte | `YB`   | `10e24` |
 
 ### Units difference
 
 Between [Decimal](#decimal) and [Binary](#binary) units of measurement, [Binary](#binary) units express data size more accurately.
 
-The size difference between `100 Kilobyte` and `100 Kibibyte` is just roughly 2.35%. However, this disparity shouldn't be ignored since it grows as the number of data values rises.
-
-For example, the size difference between `100 TB` and `100 TiB` is about 9.06%.
-
-Although there is no right or wrong answer, [Binary](#binary) units are **usually** more used for measurement of software data, while [Decimal](#decimal) is widely used to measure memory of hardwares.
+For example, the size difference between `100 Kilobyte` and `100 Kibibyte` is just roughly 2.35%. However, this disparity grows as the number of data value rises.

--- a/docs/UNBYTED_API.md
+++ b/docs/UNBYTED_API.md
@@ -1,0 +1,103 @@
+# Unbyted API
+
+Here are information about **Unbyted API**.
+
+- [Unbyted API](#unbyted-api)
+  - [unbyted(\[options\])](#unbytedoptions)
+    - [.toBinaryString(bytes)](#tobinarystringbytes)
+    - [.toDecimalString(bytes)](#todecimalstringbytes)
+  - [Usage](#usage)
+    - [trim](#trim)
+    - [symbols](#symbols)
+    - [includeBytes](#includebytes)
+    - [digits](#digits)
+    - [precision](#precision)
+    - [locales](#locales)
+    - [unitDisplay](#unitdisplay)
+  - [Other Resources](#other-resources)
+
+## unbyted([options])
+
+**Added: v1.2.0**
+
+- `options` [\<Object\>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#objects)
+  - `trim` [\<boolean\>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#boolean_type) Trim decimal numbers when needed. **Default:** `false`
+  - `symbols` [\<boolean\>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#boolean_type) Include unit's symbols or not. **Default:** `true`
+  - `includeBytes` [\<boolean\>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#boolean_type) Display bytes (B) unit or not. **Default:** `false`
+  - `digits` [\<number\>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#number_type) Change the number of fraction digits. **Default:** `2`
+  - `precision` [\<number\>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#number_type) Change the conversion precision. **Default:** `9`
+  - `locales` [\<string\>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#string_type) Change the locales used. **Default:** `en`
+  - `unitDisplay` [\<string\>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#string_type) Change the unit symbol display. **Default:** `short`
+
+All the options can work with [.toDecimalString()](#todecimalstringbytes) or [.toBinaryString()](#tobinarystringbytes).
+
+> ⚠️ The options `digits` and `precision` can severely affect the accuracy nor performance, use them carefully.
+
+### .toBinaryString(bytes)
+
+**Added: v0.1.0**
+
+- `bytes` [\<number\>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#number_type) the bytes to be converted.
+
+### .toDecimalString(bytes)
+
+**Added: v0.1.0**
+
+- `bytes` [\<number\>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#number_type) the bytes to be converted.
+
+## Usage
+
+### trim
+
+```js
+unbyted({ trim: false }).toDecimalString(1000) // Returns: 1.00 KB
+unbyted({ trim: true }).toDecimalString(1000) // Returns: 1 KB
+```
+
+### symbols
+
+```js
+unbyted({ symbols: true }).toDecimalString(1000) // Returns: 1.00 KB
+unbyted({ symbols: false }).toDecimalString(1000) // Returns: 1.00
+```
+
+### includeBytes
+
+```js
+unbyted({ includeBytes: false }).toDecimalString(100) // Returns: 0.10 KB
+unbyted({ includeBytes: true }).toDecimalString(100) // Returns: 100 B
+```
+
+### digits
+
+```js
+unbyted({ digits: 0 }).toBinaryString(100) // Returns: 0 KiB
+unbyted({ digits: 2 }).toBinaryString(100) // Returns: 0.10 KiB
+unbyted({ digits: 4 }).toBinaryString(100) // Returns: 0.0977 KiB
+```
+
+### precision
+
+```js
+unbyted({ precision: 9 }).toBinaryString(1000000) // Returns: 976.56 KiB
+unbyted({ precision: 2 }).toBinaryString(1000000) // Returns: 977.00 KiB
+```
+
+### locales
+
+```js
+unbyted({ locales: 'en' }).toBinaryString(100) // Returns: 12.06 KiB
+unbyted({ locales: 'pt' }).toBinaryString(100) // Returns: 12,06 KiB
+```
+
+### unitDisplay
+
+```js
+unbyted({ unitDisplay: 'short' }).toBinaryString(100) // Returns: 0.10 KiB
+unbyted({ unitDisplay: 'narrow' }).toBinaryString(100) // Returns: 0.10KiB
+unbyted({ unitDisplay: 'long' }).toBinaryString(100) // Returns: 0.10 Kibibyte
+```
+
+## Other Resources
+
+- [Unbyted Measurement Units](MEASUREMENT_UNITS.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unbyted",
-  "version": "0.4.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "unbyted",
-      "version": "0.4.0",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@jest/globals": "^29.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "unbyted",
   "description": "Turn bytes into readable measurement units.",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./@types/index.d.ts",

--- a/package/helpers.ts
+++ b/package/helpers.ts
@@ -1,0 +1,45 @@
+export const max = Math.max
+export const min = Math.min
+export const log10 = Math.log10
+export const log = Math.log
+export const floor = Math.floor
+
+/**
+ * Returns the logarithm value of `x` nor `y`. For numbers up to `2e20` the
+ * value is between 0 to 6.
+ *
+ * Example:
+ *
+ * **For binary units `1024 = 2e+10`:**
+ * - Cache the result of `Math.log(x)`, then multiply by `Math.log(y)`. Which,
+ *   in principle, should speed up things.
+ *
+ * **For decimal units `1000 = 10e+3`:**
+ * - Calculate the base 10 logarithm of `x` divided by 3. Again,
+ *   in principle, it should speed up things.
+ *
+ * @param x the bytes entered by the user.
+ * @param y either `1024` for **binary** units or `1000` for *decimal* units
+ * @return an floating point number.
+ * @since 2.0.0
+ */
+export function getLog(x: number, y: number): number {
+  if (y === 1000) {
+    const cache = log10(x)
+    return cache / 3
+  }
+  const cache = log(x)
+  return cache / log(y)
+}
+
+/**
+ * Returns the exponent value for the unit conversion.
+ * @param log the logarithm value from `getLog` function
+ * @param units a list containing the measurement units
+ * @param bytes a boolean to control if the smaller unit (byte) should be included or not
+ * @return the exponent value
+ * @since 2.0.0
+ */
+export function getExponent(log: number, units: string[], bytes: boolean): number {
+  return min(max(bytes ? 0 : 1, floor(log)), units.length - 1)
+}

--- a/package/types.ts
+++ b/package/types.ts
@@ -8,16 +8,14 @@ export interface UnbytedOptions {
   symbols?: boolean
   /** Display bytes (B) unit or not. (default: false) */
   includeBytes?: boolean
-  /** The number of decimal places. (default: 2) */
-  decimals?: number
-  /** The bytes value in one binary unit. (default: `1024`) */
-  bytesInBinary?: number
-  /** The bytes value in one decimal unit. (default: `1000`) */
-  bytesInDecimal?: number
-  /** Define custom decimal units symbols. (Requires 7 strings) */
-  binaryUnits?: [string, string, string, string, string, string, string]
-  /** Define custom binary units symbols. (Requires 7 strings) */
-  decimalUnits?: [string, string, string, string, string, string, string]
+  /** The number of decimal places. (default: 3) */
+  digits?: number
+  /** Change the conversion precision. (default: 9) */
+  precision?: number
+  /** Change the locales format used. (default: en) */
+  locales?: string
+  /** Change the unit symbol display. (default: short) */
+  unitDisplay?: 'long' | 'short' | 'narrow'
 }
 
 export type FormatConfig = Required<UnbytedOptions>
@@ -25,16 +23,16 @@ export type FormatConfig = Required<UnbytedOptions>
 export type UnbytedReturns = {
   /**
    * Formats bytes into readable `binary` measurement units.
-   * @param {number} bytes the bytes to be formatted
-   * @return {string} an string containing the formatted bytes
+   * @param bytes the bytes to be formatted
+   * @return an string containing the formatted bytes
    * @since v0.1.0
    */
   toBinaryString(bytes: number): string
 
   /**
    * Formats bytes into readable `decimal` measurement units.
-   * @param {number} bytes the bytes to be formatted
-   * @return {string} an string containing the formatted bytes
+   * @param bytes the bytes to be formatted
+   * @return an string containing the formatted bytes
    * @since v0.1.0
    */
   toDecimalString(bytes: number): string

--- a/package/unbyted.ts
+++ b/package/unbyted.ts
@@ -12,57 +12,20 @@ import { FormatConfig, UnbytedOptions, UnbytedReturns } from './types'
  * ```
  */
 export function unbyted(options: UnbytedOptions = {}): UnbytedReturns {
-  const {
-    symbols,
-    includeBytes,
-    trim,
-    decimals,
-    binaryUnits,
-    decimalUnits,
-    bytesInBinary,
-    bytesInDecimal,
-  } = options
-
-  if (binaryUnits instanceof Array && binaryUnits.length !== 7) {
-    throw new Error('binaryUnits requires an array containing 7 units.')
-  }
-  if (decimalUnits instanceof Array && decimalUnits.length !== 7) {
-    throw new Error('decimalUnits requires an array containing 7 units.')
-  }
-
-  const defaultBinaryUnits: UnbytedOptions['binaryUnits'] = [
-    'B',
-    'KiB',
-    'MiB',
-    'GiB',
-    'TiB',
-    'PiB',
-    'EiB',
-  ]
-
-  const defaultDecimalUnits: UnbytedOptions['decimalUnits'] = [
-    'B',
-    'KB',
-    'MB',
-    'GB',
-    'TB',
-    'PB',
-    'EB',
-  ]
+  const { symbols, includeBytes, trim, digits, unitDisplay, locales, precision } = options
 
   const config: FormatConfig = {
     symbols: typeof symbols === 'boolean' ? symbols : true,
     includeBytes: typeof includeBytes === 'boolean' ? includeBytes : false,
     trim: typeof trim === 'boolean' ? trim : false,
-    decimals: typeof decimals === 'number' ? decimals : 2,
-    binaryUnits: binaryUnits instanceof Array ? binaryUnits : defaultBinaryUnits,
-    decimalUnits: decimalUnits instanceof Array ? decimalUnits : defaultDecimalUnits,
-    bytesInBinary: typeof bytesInBinary !== 'number' ? 1024 : bytesInBinary,
-    bytesInDecimal: typeof bytesInDecimal !== 'number' ? 1000 : bytesInDecimal,
+    digits: typeof digits === 'number' ? digits : 2,
+    locales: typeof locales === 'string' ? locales : 'en',
+    unitDisplay: typeof unitDisplay === 'string' ? unitDisplay : 'short',
+    precision: typeof precision === 'number' ? precision : 9,
   }
 
   return {
-    toBinaryString: (bytes: number): string => autoFormat(bytes, 'binaryUnits', config),
-    toDecimalString: (bytes: number): string => autoFormat(bytes, 'decimalUnits', config),
+    toBinaryString: (bytes: number): string => autoFormat(bytes, 0, config),
+    toDecimalString: (bytes: number): string => autoFormat(bytes, 1, config),
   }
 }

--- a/package/units.ts
+++ b/package/units.ts
@@ -1,0 +1,30 @@
+export const UNITS = [
+  [
+    [
+      'Byte',
+      'Kibibyte',
+      'Mebibyte',
+      'Gibibyte',
+      'Tebibyte',
+      'Pebibyte',
+      'Exbibyte',
+      'Zebibyte',
+      'Yobibyte',
+    ],
+    ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'],
+  ],
+  [
+    [
+      'Byte',
+      'Kilobyte',
+      'Megabyte',
+      'Gibabyte',
+      'Terabyte',
+      'Petabyte',
+      'Exabyte',
+      'Zettabyte',
+      'Yottabyte',
+    ],
+    ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'],
+  ],
+]

--- a/test/unbyted.test.ts
+++ b/test/unbyted.test.ts
@@ -1,27 +1,40 @@
 import { describe, expect, test } from '@jest/globals'
 import unbyted from '../package/index'
 
+const yotta = 2e25
+const zetta = 2e22
+const exa = 2e20
+const peta = 2e16
+const tera = 2e12
+const giga = 2e10
+const mega = 2e8
+const kilo = 2e4
+
 describe('new Unbyted instance', () => {
-  test('exposes the public API', () => {
-    const methods = unbyted()
-
-    expect(methods).toHaveProperty('toBinaryString')
-    expect(methods).toHaveProperty('toDecimalString')
-  })
-
   test('turns bytes to binary string', () => {
     const methods = unbyted()
 
-    expect(methods.toBinaryString(0)).toBe('0.00 KiB')
-    expect(methods.toBinaryString(100)).toBe('0.10 KiB')
-    expect(methods.toBinaryString(-100)).toBe('0.00 KiB')
+    expect(methods.toBinaryString(kilo)).toBe('19.53 KiB')
+    expect(methods.toBinaryString(mega)).toBe('190.73 MiB')
+    expect(methods.toBinaryString(giga)).toBe('18.63 GiB')
+    expect(methods.toBinaryString(tera)).toBe('1.82 TiB')
+    expect(methods.toBinaryString(peta)).toBe('17.76 PiB')
+    expect(methods.toBinaryString(exa)).toBe('173.47 EiB')
+    expect(methods.toBinaryString(zetta)).toBe('16.94 ZiB')
+    expect(methods.toBinaryString(yotta)).toBe('16.54 YiB')
   })
 
   test('turns bytes to decimal string', () => {
     const methods = unbyted()
 
-    expect(methods.toDecimalString(0)).toBe('0.00 KB')
-    expect(methods.toDecimalString(100)).toBe('0.10 KB')
+    expect(methods.toDecimalString(kilo)).toBe('20.00 KB')
+    expect(methods.toDecimalString(mega)).toBe('200.00 MB')
+    expect(methods.toDecimalString(giga)).toBe('20.00 GB')
+    expect(methods.toDecimalString(tera)).toBe('2.00 TB')
+    expect(methods.toDecimalString(peta)).toBe('20.00 PB')
+    expect(methods.toDecimalString(exa)).toBe('200.00 EB')
+    expect(methods.toDecimalString(zetta)).toBe('20.00 ZB')
+    expect(methods.toDecimalString(yotta)).toBe('20.00 YB')
   })
 
   test('trowns when given invalid bytes', () => {
@@ -33,6 +46,7 @@ describe('new Unbyted instance', () => {
     expect(() => methods.toBinaryString(null)).toThrow()
     // @ts-expect-error: tests error handling
     expect(() => methods.toBinaryString('100')).toThrow()
+    expect(() => methods.toBinaryString(Infinity)).toThrow()
 
     // @ts-expect-error: tests error handling
     expect(() => methods.toDecimalString({})).toThrow()
@@ -40,95 +54,69 @@ describe('new Unbyted instance', () => {
     expect(() => methods.toDecimalString(null)).toThrow()
     // @ts-expect-error: tests error handling
     expect(() => methods.toDecimalString('100')).toThrow()
-  })
-
-  test('trim measurement unit value', () => {
-    const methods = unbyted({ trim: true })
-
-    expect(methods.toBinaryString(100)).toBe('0.1 KiB')
-    expect(methods.toDecimalString(100)).toBe('0.1 KB')
-  })
-
-  test('remove measurement unit symbols', () => {
-    const methods = unbyted({ symbols: false })
-
-    expect(methods.toBinaryString(100)).toBe('0.10')
-    expect(methods.toDecimalString(100)).toBe('0.10')
-  })
-
-  test('display bytes (B) measurement unit', () => {
-    const methods = unbyted({ includeBytes: true })
-
-    expect(methods.toBinaryString(100)).toBe('100.00 B')
-    expect(methods.toDecimalString(100)).toBe('100.00 B')
-  })
-
-  test('custom decimal places / floating points', () => {
-    const methods = unbyted({ decimals: 1 })
-
-    expect(methods.toBinaryString(100)).toBe('0.1 KiB')
-    expect(methods.toDecimalString(100)).toBe('0.1 KB')
-  })
-
-  test('custom default binary units values', () => {
-    const methods = unbyted({ bytesInBinary: 1000 })
-
-    expect(methods.toBinaryString(10000)).toBe('10.00 KiB')
-  })
-
-  test('custom default decimal units values', () => {
-    const methods = unbyted({ bytesInDecimal: 1024 })
-
-    expect(methods.toDecimalString(10000)).toBe('9.77 KB')
+    expect(() => methods.toDecimalString(Infinity)).toThrow()
   })
 })
 
-describe('Custom measurement units symbols', () => {
-  test('valid custom binary units symbols', () => {
-    const methods = unbyted({
-      binaryUnits: [
-        'Bytes',
-        'Kibibytes',
-        'Mebibytes',
-        'Gigibytes',
-        'Tebibytes',
-        'Pebibytes',
-        'Exbibytes',
-      ],
-    })
+describe('Unbyted Options', () => {
+  test('trim', () => {
+    const methods = unbyted({ trim: true })
 
-    expect(methods.toBinaryString(100)).toBe('0.10 Kibibytes')
+    expect(methods.toBinaryString(0)).toBe('0 KiB')
+    expect(methods.toDecimalString(0)).toBe('0 KB')
   })
 
-  test('valid custom decimal units symbols', () => {
-    const methods = unbyted({
-      decimalUnits: [
-        'Bytes',
-        'Kilobytes',
-        'Megabytes',
-        'Gigabytes',
-        'Terabytes',
-        'Petabytes',
-        'Exabytes',
-      ],
-    })
+  test('unitDisplay - short', () => {
+    const methods = unbyted({ unitDisplay: 'short' })
 
-    expect(methods.toDecimalString(100)).toBe('0.10 Kilobytes')
+    expect(methods.toBinaryString(0)).toBe('0.00 KiB')
+    expect(methods.toDecimalString(0)).toBe('0.00 KB')
   })
 
-  test('throws if 7 custom measurement units symbols are not provided', () => {
-    expect(() =>
-      unbyted({
-        // @ts-expect-error: tests error handling
-        binaryUnits: ['Bytes', 'Kibibytes', 'Mebibytes'],
-      })
-    ).toThrow()
+  test('unitDisplay - narrow', () => {
+    const methods = unbyted({ unitDisplay: 'narrow' })
 
-    expect(() =>
-      unbyted({
-        // @ts-expect-error: tests error handling
-        decimalUnits: ['Bytes', 'Kilobytes', 'Megabytes'],
-      })
-    ).toThrow()
+    expect(methods.toBinaryString(0)).toBe('0.00KiB')
+    expect(methods.toDecimalString(0)).toBe('0.00KB')
+  })
+
+  test('unitDisplay - narrow', () => {
+    const methods = unbyted({ unitDisplay: 'long' })
+
+    expect(methods.toBinaryString(0)).toBe('0.00 Kibibyte')
+    expect(methods.toDecimalString(0)).toBe('0.00 Kilobyte')
+  })
+
+  test('symbols', () => {
+    const methods = unbyted({ symbols: false })
+
+    expect(methods.toBinaryString(0)).toBe('0.00')
+    expect(methods.toDecimalString(0)).toBe('0.00')
+  })
+
+  test('includeBytes', () => {
+    const methods = unbyted({ includeBytes: true })
+
+    expect(methods.toDecimalString(200)).toBe('200.00 B')
+  })
+
+  test('digits', () => {
+    const methods = unbyted({ digits: 0 })
+
+    expect(methods.toDecimalString(kilo)).toBe('20 KB')
+  })
+
+  test('locales', () => {
+    const methods = unbyted({ locales: 'pt-BR' })
+
+    expect(methods.toBinaryString(kilo)).toBe('19,53 KiB')
+    expect(methods.toDecimalString(kilo)).toBe('20,00 KB')
+  })
+
+  test('precision', () => {
+    const methods = unbyted({ precision: 3 })
+
+    expect(methods.toBinaryString(mega)).toBe('191.00 MiB')
+    expect(methods.toDecimalString(mega)).toBe('200.00 MB')
   })
 })


### PR DESCRIPTION
**Breaking changes**

- Remove options `bytesInBinary` and `bytesInDecimal`
- Remove options `binaryUnits` and `decimalUnits`
- Rename option `decimals` to `digits`

**Features**

- Add support for `Zettabyte`,`Yottabyte`, `Zebibyte`, and `Yobibyte`
- Add support for different unit formats
- Add support to control the precision of the conversion
- Add support to control the locales format of the values
- Add API documentation
- Update measurement unit guide docs

**Additional Context**

Resolves #29, resolves #30, resolves #31, resolves #32 